### PR TITLE
don't add blank names

### DIFF
--- a/lib/graph.rb
+++ b/lib/graph.rb
@@ -8,7 +8,7 @@ class Graph
 
   def add_node(name)
     log("node: #{name}")
-    @g.add_node(name)
+    @g.add_node(name) if name
   end
 
   def get_node(name, &block)


### PR DESCRIPTION
A blank node name was causing:

```
Value for attribute `label` can't be null
/Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz.rb:961:in `escape': undefined method `match' for nil:NilClass (NoMethodError)
    from /Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz/node.rb:141:in `output'
    from /Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz.rb:638:in `block in append_attributes_and_types'
    from /Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz/elements.rb:19:in `block in each'
    from /Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz/elements.rb:18:in `each'
    from /Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz/elements.rb:18:in `each'
    from /Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz.rb:624:in `append_attributes_and_types'
    from /Users/mferrante/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/ruby-graphviz-1.2.1/lib/graphviz.rb:445:in `output'
    from /Users/mferrante/code/aws-security-viz/lib/graph.rb:29:in `output'
    from lib/visualize_aws.rb:35:in `render'
    from lib/visualize_aws.rb:15:in `unleash'
    from lib/visualize_aws.rb:51:in `<main>'
```

This fixed the issue.
