### PR TITLE
Add a region parameter to allow for querying a different region

### DIFF
--- a/lib/provider/ec2.rb
+++ b/lib/provider/ec2.rb
@@ -3,7 +3,7 @@ require 'fog'
 class Ec2Provider
 
   def initialize(options)
-    @compute = Fog::Compute.new(:provider => 'AWS', :aws_access_key_id => options[:access_key], :aws_secret_access_key => options[:secret_key])
+    @compute = Fog::Compute.new(:provider => 'AWS', :aws_access_key_id => options[:access_key], :aws_secret_access_key => options[:secret_key], :region => options[:region])
   end
 
   def security_groups

--- a/lib/visualize_aws.rb
+++ b/lib/visualize_aws.rb
@@ -40,6 +40,7 @@ if __FILE__ == $0
   opts = Trollop::options do
     opt :access_key, 'AWS access key', :type => :string
     opt :secret_key, 'AWS secret key', :type => :string
+    opt :region, 'AWS region to query', :default => 'us-east-1', :type => :string
     opt :source_file, 'JSON source file containing security groups', :type => :string
     opt :filename, 'Output file name', :type => :string, :default => 'aws-security-viz.png'
   end


### PR DESCRIPTION
By default, the region to query is us-east-1. Our entire infrastructure was in a different region and because of that, our .svg was output empty other than the default security group. 

This adds a region parameter to pass on the command-line that allows you to specify the AWS region to query.
