### PR TITLE
Fix for issue #1 (more concise node names)

### DIFF
--- a/lib/aws_security_viz.rb
+++ b/lib/aws_security_viz.rb
@@ -32,7 +32,7 @@ class VisualizeAws
     g = @config.obfuscate? ? DebugGraph.new(@config) : Graph.new(@config)
     @security_groups.each_with_index { |group, index|
       picker = ColorPicker.new(@options[:color])
-      g.add_node(group.name)
+      g.add_node(group.name, group.labels)
       group.traffic.each { |traffic|
         if traffic.ingress
           g.add_edge(traffic.from, traffic.to, :color => picker.color(index, traffic.ingress), :label => traffic.port_range)

--- a/lib/ec2/security_groups.rb
+++ b/lib/ec2/security_groups.rb
@@ -29,6 +29,8 @@ end
 class SecurityGroup
   extend Forwardable
 
+  # @group is an Ec2::SecurityGroup
+
   def_delegator :@group, :name
 
   def initialize(all_groups, group, config)
@@ -36,6 +38,11 @@ class SecurityGroup
     @group = group
     @config = config
   end
+
+  def labels
+    fsg = @group.instance_variable_get(:@sg)
+    labels = { "id" => fsg.group_id, "name" => fsg.name, "tag:Name" => fsg.tags['Name'], "tag:eb-env-name" => fsg.tags['elasticbeanstalk:environment-name'] }
+   end
 
   def permissions
     ingress_permissions = @group.ip_permissions.collect { |ip|

--- a/lib/graph.rb
+++ b/lib/graph.rb
@@ -7,10 +7,10 @@ class Graph
     @nodes = Set.new
   end
 
-  def add_node(name)
-    log("node: #{name}")
-    uniquely_add(@ops, :node, name) {
-      [:node, name]
+  def add_node(name, labels={})
+    log("node: #{name} labels: #{labels}")
+    uniquely_add(@ops, :node, name, labels) {
+      [:node, name, labels]
     }
   end
 

--- a/lib/renderer/graphviz.rb
+++ b/lib/renderer/graphviz.rb
@@ -13,11 +13,23 @@ module Renderer
       @config = config
     end
 
-    def add_node(name)
-      @g.add_node(name)
+    def add_node(name, labels={})
+      log("renderer considering node #{name} with labels: #{labels}")
+      node = @g.add_node(name)
+      
+      if !labels.empty?
+        rows = ""
+        labels.each_pair { |key, value| rows+="<tr><td>#{key}</td><td>#{value}</td></tr>" }
+        label="<<table>#{rows}</table>>"
+        
+        node.set { |_n|
+          _n.label = label
+        }
+        end
     end
 
     def add_edge(from, to, opts)
+      log(opts)
       @g.add_edge(from, to, ({style: 'bold'}).merge(opts))
     end
 
@@ -26,5 +38,9 @@ module Renderer
       opts = {extension[1..-1].to_sym => @file_name, :use => @config.format}
       @g.output(opts)
     end
+
+    def log(msg)
+      puts msg if @config.debug?
+    end    
   end
 end


### PR DESCRIPTION
Now using a hard-coded set of values (sg id, name, and a few tags) as labels in the graph nodes. Makes the graph more compact and descriptive.