### PR TITLE
Allow aws auth with session_tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-aws-security-viz -- A tool to visualize aws security groups 
+aws-security-viz -- A tool to visualize aws security groups
 ============================================================
-[![Build Status](https://secure.travis-ci.org/anaynayak/aws-security-viz.png)](http://travis-ci.org/anaynayak/aws-security-viz) 
+[![Build Status](https://secure.travis-ci.org/anaynayak/aws-security-viz.png)](http://travis-ci.org/anaynayak/aws-security-viz)
 [![Gem Version](https://badge.fury.io/rb/aws_security_viz.svg)](https://badge.fury.io/rb/aws_security_viz)
 [![License](https://img.shields.io/github/license/anaynayak/aws-security-viz.svg?maxAge=2592000)]()
-[![Code Climate](https://codeclimate.com/github/anaynayak/aws-security-viz.png)](https://codeclimate.com/github/anaynayak/aws-security-viz) 
+[![Code Climate](https://codeclimate.com/github/anaynayak/aws-security-viz.png)](https://codeclimate.com/github/anaynayak/aws-security-viz)
 [![Dependency Status](https://gemnasium.com/anaynayak/aws-security-viz.png)](https://gemnasium.com/anaynayak/aws-security-viz)
 
 ## DESCRIPTION
-  Need a quick way to visualize your current aws/amazon ec2 security group configuration? aws-security-viz does just that based on the EC2 security group ingress configuration. 
+  Need a quick way to visualize your current aws/amazon ec2 security group configuration? aws-security-viz does just that based on the EC2 security group ingress configuration.
 
 ## FEATURES
 
-* Output to any of the formats that Graphviz supports. 
+* Output to any of the formats that Graphviz supports.
 * EC2 classic and VPC security groups
 
-## INSTALLATION 
+## INSTALLATION
 ```
   $ gem install aws_security_viz
   $ aws_security_viz --help
@@ -23,7 +23,7 @@ aws-security-viz -- A tool to visualize aws security groups
 ## DEPENDENCIES
 
 * graphviz with triangulation `brew install graphviz --with-gts`
-* libxml2 `brew install libxml2`* 
+* libxml2 `brew install libxml2`*
 
 ## USAGE
 
@@ -45,23 +45,27 @@ To generate a web view
   $ aws_security_viz -a your_aws_key -s your_aws_secret_key -f aws.json
 ```
 
-* Generates two files: aws.json and view.html. 
-* The json file name needs to be passed in as a html fragment identifier. 
+* Generates two files: aws.json and view.html.
+* The json file name needs to be passed in as a html fragment identifier.
 * The generated graph can be viewed in a webserver e.g. http://localhost:3000/view.html#aws.json by using `python -m SimpleHTTPServer 3000` (python2) or `python -m http.server 3000` (python3)
 
 ### Help
 
-``` 
+```
 $ aws_security_viz --help
 Options:
-  -a, --access-key=<s>     AWS access key
-  -s, --secret-key=<s>     AWS secret key
-  -r, --region=<s>         AWS region to query (default: us-east-1)
-  -o, --source-file=<s>    JSON source file containing security groups
-  -f, --filename=<s>       Output file name (default: aws-security-viz.png)
-  -c, --config=<s>         Config file (opts.yml) (default: opts.yml)
-  -l, --color              Colored node edges
-  -h, --help               Show this message
+  -a, --access-key=<s>       AWS access key
+  -s, --secret-key=<s>       AWS secret key
+  -e, --session-token=<s>    AWS session token
+  -r, --region=<s>           AWS region to query (default: us-east-1)
+  -v, --vpc-id=<s>           AWS VPC id to show
+  -o, --source-file=<s>      JSON source file containing security groups
+  -f, --filename=<s>         Output file name (default: aws-security-viz.png)
+  -c, --config=<s>           Config file (opts.yml) (default: opts.yml)
+  -l, --color                Colored node edges
+  -u, --source-filter=<s>    Source filter
+  -t, --target-filter=<s>    Target filter
+  -h, --help                 Show this message
 ```
 
 #### Advanced configuration
@@ -73,13 +77,13 @@ You can generate a configuration file using the following command:
 
 The opts.yml file lets you define the following options:
 
-* Grouping of CIDR ips 
+* Grouping of CIDR ips
 * Define exclusion patterns
 * Change graphviz format (neato, dot, sfdp etc)
 
 ## DEBUGGING
 
-To generate the graph with debug statements, execute the following command 
+To generate the graph with debug statements, execute the following command
 
 ```
 $ DEBUG=true aws_security_viz -a your_aws_key -s your_aws_secret_key -f viz.svg

--- a/exe/aws_security_viz
+++ b/exe/aws_security_viz
@@ -6,6 +6,7 @@ require 'trollop'
 opts = Trollop::options do
   opt :access_key, 'AWS access key', :default => ENV['AWS_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY_ID'], :type => :string
   opt :secret_key, 'AWS secret key', :default => ENV['AWS_SECRET_KEY'] || ENV['AWS_SECRET_ACCESS_KEY'], :type => :string
+  opt :session_token, 'AWS session token', :default => ENV['AWS_SESSION_TOKEN'] || nil, :type => :string
   opt :region, 'AWS region to query', :default => 'us-east-1', :type => :string
   opt :vpc_id, 'AWS VPC id to show', :type => :string
   opt :source_file, 'JSON source file containing security groups', :type => :string

--- a/lib/provider/ec2.rb
+++ b/lib/provider/ec2.rb
@@ -11,6 +11,10 @@ class Ec2Provider
     conn_opts[:aws_access_key_id] = options[:access_key]
     conn_opts[:aws_secret_access_key] = options[:secret_key]
 
+    if options[:session_token]
+      conn_opts[:aws_session_token] = options[:session_token]
+    end
+
     @compute = Fog::Compute::AWS.new conn_opts
   end
 


### PR DESCRIPTION
I don't use long lived credentials for anything as is best practice in the AWS ecosystem these days, this PR simply allows you to leverage a session token if needed. My editor also cleaned up some unneeded whitespace in the README.