### PR TITLE
Use add rankdir option to improve the look

### DIFF
--- a/lib/renderer/graphviz.rb
+++ b/lib/renderer/graphviz.rb
@@ -8,6 +8,7 @@ module Renderer
         g[:splines] = :true
         g[:sep] = 1
         g[:concentrate] = :true
+        g[:rankdir] = "LR"
       }
       @file_name = file_name
       @config = config


### PR DESCRIPTION
Right now all networks are source nodes and this way have a rank of 0
means they are all placed on top, side by side. In a network with a lot
of subnets the picture becomes wider which makes it hard to read and
complicated to scroll.

With this change, the graph direction switches from top to down to left
to right and this way subnets will belisted on the left side.
Pictures now become higher instead of wider and become a bit easier to
navigate, since nodes also becomes closer since they take way less
space.

Signed-off-by: Sheogorath <sheogorath@shivering-isles.com>