### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest
+RUN apt-get update
+# RUN gem install aws_security_viz # use bundler instead because nokogiri makes problems
+RUN apt-get install -y git ruby-dev ruby graphviz libxml2-dev g++ zlib1g-dev python
+RUN git clone https://github.com/anaynayak/aws-security-viz.git
+WORKDIR /aws-security-viz
+RUN gem install bundler --no-document
+RUN bundle install
+ENTRYPOINT ["/bin/sh"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you don't want to install the dependencies and ruby libs you can execute aws-
 2. Build the docker container: `sudo docker build -t sec-viz .`
 3. Run the container: `sudo docker run -i --rm -t -p 3000:3000 --name sec-viz sec-viz` (Description: `-i` interactive shell, `--rm` remove the container after usage, `-t` attach this terminal to it, `-p 3000:3000` we expose port 3000 for the HTTP server, `-name sec-viz` the container will have the same name as the image we will start)
 4. Now you can use the tool as described in [usage](#USAGE). Make sure that you use the commands with `bundler exec ` as prefix. For example: `bundler exec aws_security_viz -a your_aws_key -s your_aws_secret_key -f aws.json`.
-5. The web view can be generated executing `python -m SimpleHTTPServer 3000` in the container. You can open it with you local browser at `http://0.0.0.0:3000/`. There you can view the generated images and the graph. Use `Ctrl+C` to close the HTTP server.
+5. To start the web view, execute `python -m SimpleHTTPServer 3000` in the container. You can open it with your local browser at `http://0.0.0.0:3000/`. There you can view the generated images and the graph. Use `Ctrl+C` to close the HTTP server.
 6. Terminate the docker container by typing `exit` in the console.
 
 ### Help

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ To generate a web view
 * The json file name needs to be passed in as a html fragment identifier.
 * The generated graph can be viewed in a webserver e.g. http://localhost:3000/view.html#aws.json by using `python -m SimpleHTTPServer 3000` (python2) or `python -m http.server 3000` (python3)
 
+## DOCKER USAGE
+
+If you don't want to install the dependencies and ruby libs you can execute aws-security-viz inside a docker container. To do so, follow these steps:
+
+1. Clone this repository, open it in a console.
+2. Build the docker container: `sudo docker build -t sec-viz .`
+3. Run the container: `sudo docker run -i --rm -t -p 3000:3000 --name sec-viz sec-viz` (Description: `-i` interactive shell, `--rm` remove the container after usage, `-t` attach this terminal to it, `-p 3000:3000` we expose port 3000 for the HTTP server, `-name sec-viz` the container will have the same name as the image we will start)
+4. Now you can use the tool as described in [usage](#USAGE). Make sure that you use the commands with `bundler exec ` as prefix. For example: `bundler exec aws_security_viz -a your_aws_key -s your_aws_secret_key -f aws.json`.
+5. The web view can be generated executing `python -m SimpleHTTPServer 3000` in the container. You can open it with you local browser at `http://0.0.0.0:3000/`. There you can view the generated images and the graph. Use `Ctrl+C` to close the HTTP server.
+6. Terminate the docker container by typing `exit` in the console.
+
 ### Help
 
 ```


### PR DESCRIPTION
Hi,

I created a Dockerfile to use the tool without installing something else. It simply installs the dependencies, clones the repository and installs aws-security-viz with bundler. It can be used with the interactive terminal mode. The generated files can be viewed using the Python HTTP server.

The generated docker image is quite big. It currently uses 613MB, so there is definitely room for improvement. Because of some strange problems I was unable to use Alpine Linux as base image. Maybe someone else has more luck / skill with that.

Best regards and thanks for the great work!
Lars