### PR TITLE
switch to using https in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
Running bundle audit check reports one vulnerability due to accessing rubygems over http. Seems to work fine over https and this removes the warning about vulnerabilities

*before*
```
bundle audit check --update
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up to date.
Updated ruby-advisory-db
ruby-advisory-db: 331 advisories
Insecure Source URI found: http://rubygems.org/
Vulnerabilities found!
```
*after*
```
bundle audit check --update
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up to date.
Updated ruby-advisory-db
ruby-advisory-db: 331 advisories
No vulnerabilities found
```